### PR TITLE
JSON.stringify() ignores money objects

### DIFF
--- a/source/moneysafe.js
+++ b/source/moneysafe.js
@@ -29,12 +29,24 @@ const m$ = ({
       constructor: $,
       toString () {
         return `${ symbol }${ this.$.toFixed(decimals) }`;
+      },
+      toJSON () {
+        return this.toString();
       }
     });
   }
 
   $.of = cents => $(undefined, { cents });
   $.cents = cents => $.of(round(cents));
+  $.parse = (str) => {
+    try {
+      const pattern = /^([^\d\s]{1,3})?(\d+(?:\.\d+)?)$/;
+      const [ignore, symbol, amount] = str.match(pattern);
+      return m$({symbol})(amount);
+    } catch (err) {
+      throw new Error(`Invalid money format: '${str}'`);
+    }
+  }
 
   return $;
 };

--- a/source/moneysafe.test.js
+++ b/source/moneysafe.test.js
@@ -188,6 +188,63 @@ test('$(x).toString()', assert => {
   assert.end();
 });
 
+test('$(x).toJSON()', assert => {
+  const msg = 'should return JSON representation of the value';
+
+  const actual = $(10.10).toJSON();
+  const expected = '$10.10';
+
+  assert.same(actual, expected, msg);
+  assert.end();
+});
+
+test('JSON.stringify({ money: $(x) })', assert => {
+  const msg = 'should return JSON representation of an object containing money object';
+
+  const actual = JSON.stringify({ money: $(10.10) });
+  const expected = '{"money":"$10.10"}';
+
+  assert.same(actual, expected, msg);
+  assert.end();
+});
+
+test('$.parse(x))', assert => {
+  const msg = 'should return deserialized money object';
+
+  {
+    const actual = $.parse('$3.18').toString();
+    const expected = '$3.18';
+    assert.same(actual, expected, msg);
+  }
+
+  {
+    const actual = $.parse('65').toString();
+    const expected = '$65.00';
+    assert.same(actual, expected, msg);
+  }
+
+  {
+    const actual = $.parse('€115.26').toString();
+    const expected = '€115.26';
+    assert.same(actual, expected, msg);
+  }
+
+  {
+    const actual = $.parse('💰1000').toString();
+    const expected = '💰1000.00';
+    assert.same(actual, expected, msg);
+  }
+
+  assert.end();
+});
+
+test('$.parse(x))', assert => {
+  const msg = 'should throw error on invalid money format';
+
+  assert.throws(() => $.parse('100 USD'), Error, msg);
+  assert.end();
+});
+
 test('m$({ symbol: \'#\' })(x).toString()', assert => {
   const msg = 'should return string with custom currency symbol';
   const p = m$({ symbol: '#' });


### PR DESCRIPTION
Repro:
```javascript

import { $ } from 'moneysafe';

const product = {
  name: 'toy',
  cost: $(12.52)
};

console.log(JSON.stringify(product)); // will output {"name":"toy"}
```
By adding `toJSON()`the money objects are serialized as expected.
```javascript
{"name":"toy","cost":"$12.52"}
```

This pull request includes the fix. I also added `parse()` for deserializing from string representation to money object.

```javascript
console.log(JSON.stringify(product)); // {"name":"toy","cost":"$12.52"}

console.log($.parse('$3.18').toString()); // $3.18
console.log($.parse('65').toString()); // $65.00
console.log($.parse('€115.26').toString()); // €115.26
console.log($.parse('💰1000').toString()); // 💰1000.00
console.log($.parse('100 USD').toString()); // Error: Invalid money format: '100 USD'
```