### PR TITLE
Add equals method to compare money objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,21 @@ const pow = exp => m => Array.from(
 +$(2).map(pow(2)); // 4
 ```
 
+### money.equals()
+
+Compares the value of two Money objects and returns true if they are equal, false otherwise.
+
+```js
+money.equals(other: Money) => boolean
+```
+
+Example:
+
+```js
+$(7).equals($(7)); // true
+$(7).equals($(7.009)); // false
+$(7).equals($(6.991)); // false
+```
 
 ## Utility functions
 
@@ -421,6 +436,21 @@ gte($(7), $(7)) === true; // true
 gte($(7), $(6.991)) === true; // true
 ```
 
+## Equals
+
+Take a base and a comparand and return whether the comparand is equal to the base.
+
+```js
+equals(base: Money, comparand: Money) => boolean
+```
+
+Example:
+
+```js
+equals($(7), $(7)) === true; // true
+equals($(7), $(7.009)) === false; // false
+equals($(7), $(6.991)) === false; // false
+```
 
 ## $$ Ledger
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const createCurrency = ({ decimals }) => {
     const div = b => of(value.dividedBy(op(b)));
     const toNumber = () => value.toNumber();
     const abs = () => of(value.abs());
+    const equals = b => value.isEqualTo(op(b));
 
     return Object.assign(plus, {
       [MoneySafe]: true,
@@ -40,6 +41,7 @@ const createCurrency = ({ decimals }) => {
        */
       toNumber: toNumber,
       abs,
+      equals,
       toString: () => value.toFixed(decimals)
     });
   };
@@ -104,6 +106,14 @@ const lte = (base, comparand) => base.lte(comparand);
  */
 const gte = (base, comparand) => base.gte(comparand);
 
+/**
+ * Take a base and a comparand and return whether the comparand is equal to the base.
+ * @param {Money} base
+ * @param {Money} comparand
+ * @returns { boolean }
+ */
+const equals = (base, comparand) => base.equals(comparand);
+
 module.exports = {
   createCurrency,
   $,
@@ -114,5 +124,6 @@ module.exports = {
   lt,
   gt,
   lte,
-  gte
+  gte,
+  equals
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -11,7 +11,8 @@ import {
   lt,
   gt,
   lte,
-  gte
+  gte,
+  equals
 } from './index.js';
 
 describe('money.map', async assert => {
@@ -312,6 +313,44 @@ describe('Comparative utilities: greater than or equal to', async assert => {
     assert({
       given: 'a base compared to a lower comparand',
       should: 'return true',
+      actual,
+      expected
+    });
+  }
+});
+
+describe('Comparative utilities: equals', async assert => {
+  {
+    const actual = equals($(7), $(7));
+    const expected = true;
+
+    assert({
+      given: 'two equal money objects',
+      should: 'return true',
+      actual,
+      expected
+    });
+  }
+
+  {
+    const actual = equals($(7), $(7.009));
+    const expected = false;
+
+    assert({
+      given: 'two unequal money objects',
+      should: 'return false',
+      actual,
+      expected
+    });
+  }
+
+  {
+    const actual = $(7).equals($(6.991));
+    const expected = false;
+
+    assert({
+      given: 'two unequal money objects using the equals method',
+      should: 'return false',
       actual,
       expected
     });


### PR DESCRIPTION
Fixes #18

Add `equals` method to compare money objects.

* **src/index.js**
  - Add `equals` method to the money object.
  - Implement `equals` method to compare the value of two money objects.
  - Export `equals` comparative utility.

* **src/index.test.js**
  - Add tests for the `equals` method.
  - Verify that the `equals` method correctly compares two money objects.
  - Add tests for the `equals` comparative utility.

* **README.md**
  - Document the `equals` method for money objects.
  - Provide examples of how to use the `equals` method.
  - Document the `equals` comparative utility.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ericelliott/moneysafe/issues/18?shareId=3ee0df53-373e-4934-aa2c-f69688fa5a4c).