### PR TITLE
fix: keep operand values unrounded in arithmetic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,17 @@ const BigNumber = require('bignumber.js');
 
 const MoneySafe = Symbol('MoneySafe');
 
-const op = input => BigNumber(input);
+const op = input => {
+  // A Money object carries an unrounded internal value. Coercing it with
+  // BigNumber(input) would stringify via toString (rounded to the currency
+  // precision), so unwrap the internal value to keep full precision.
+  if (input && input[MoneySafe]) {
+    let value;
+    input.map(internal => (value = internal));
+    return value;
+  }
+  return BigNumber(input);
+};
 
 const createCurrency = ({ decimals }) => {
   const of = (input, value = op(input)) => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -166,6 +166,35 @@ describe('Arithmetic utilities: add, multiply, divide, abs', async assert => {
   }
 });
 
+describe('Operands keep full precision (README: "Not rounded")', async assert => {
+  {
+    const standalone = $('1.119').toFixed(3);
+    const asOperand = $(0)
+      .plus($('1.119'))
+      .toFixed(3);
+
+    assert({
+      given:
+        'a value with more digits than the currency precision used as an operand',
+      should: 'use the unrounded value, matching the standalone value',
+      actual: asOperand,
+      expected: standalone
+    });
+  }
+
+  {
+    const actual = add($('0.114'), $('0.114'), $('0.114')).toFixed(3);
+    const expected = '0.342';
+
+    assert({
+      given: 'three sub-cent values summed with add',
+      should: 'sum the unrounded operands',
+      actual,
+      expected
+    });
+  }
+});
+
 describe('Comparative utilities: less than', async assert => {
   {
     const actual = lt($(7), $(7.009));


### PR DESCRIPTION
## What

Arithmetic silently rounds a `Money` operand to the currency precision before computing, even though the same value keeps full precision when used standalone.

```js
const { $, add } = require('moneysafe');

$('1.119').toFixed(3)                                 // '1.119'  standalone keeps precision
$(0).plus($('1.119')).toFixed(3)                      // '1.120'  operand was rounded to 1.12 first
add($('0.114'), $('0.114'), $('0.114')).toFixed(3)    // '0.334'  expected '0.342'
```

The asymmetry is the tell: a value reports `1.119` on its own, but the moment it is passed as an operand it is quietly rounded to `1.12`.

## Why this looks like a defect, not policy

The documented contract says values are not rounded until you ask:

- README, `$(value)`: "Takes a value and lifts it into the `Money` object type. **Not rounded.**"
- README: "use the arithmetic functions provided to guarantee precision"
- README: "If you want to round a Money value to its nearest supported significant digit, you can use `money.toFixed()`" (rounding is opt-in)
- In #6 you wrote: "MoneySafe operates at full IEEE 754 64-bit floating point precision by default. It only rounds when you explicitly ask it to ... All math operators automatically use the unrounded value for best precision."

The operand path is the one place that does not hold to this. `$('1.119')` stores the unrounded value, so a standalone `toFixed(3)` returns `1.119`, but using it as an operand rounds it to the cent first.

## Cause

`src/index.js`:

```js
const op = input => BigNumber(input);
```

For a `Money` operand, `BigNumber(input)` coerces via `String(input)`, which is `value.toFixed(decimals)` (rounded to the currency precision). So `op($('1.119'))` becomes `1.12` before the arithmetic runs.

## Fix

Unwrap a `Money` operand to its internal unrounded value instead of stringifying it (detected via the existing `MoneySafe` symbol). Primitive and string inputs are unchanged.

Explicit rounding stays intact: `toString()` and the default `toFixed()` still round to the currency precision, so the "round only when you ask" behavior is preserved. Verified: `$(0).plus($('1.119')).toString()` is still `'1.12'`, and the zero-decimals cases still pass.

## Tests

Added a `describe` block that asserts the operand value matches the standalone value, plus the three-operand sub-cent sum. Red before the fix, green after.

Full suite: `# tests 30 / # pass 30 / # ok`.
